### PR TITLE
초대 도메인 구현 및 테스트

### DIFF
--- a/FDP/backend/src/app.module.ts
+++ b/FDP/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthModule } from './domain/auth/auth.module';
 import { EmailModule } from './domain/email/email.module';
+import { InvitationModule } from './domain/invitation/invitation.module';
 import * as path from 'path';
 
 @Module({
@@ -40,6 +41,7 @@ import * as path from 'path';
     }),
     AuthModule,
     EmailModule,
+    InvitationModule,
   ],
   controllers: [],
   providers: [],

--- a/FDP/backend/src/domain/invitation/invitation.entity.ts
+++ b/FDP/backend/src/domain/invitation/invitation.entity.ts
@@ -18,7 +18,7 @@ export class Invitation {
   inviteCode!: string;
 
   @Column({ type: 'timestamp' })
-  expiration!: Date;
+  expiresAt!: Date;
 
   @ManyToOne(() => Group, {
     onDelete: 'SET NULL',
@@ -28,6 +28,9 @@ export class Invitation {
 
   @Column({ type: 'boolean', default: true })
   isActive!: boolean;
+
+  @Column()
+  createdById!: string;
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt!: Date;

--- a/FDP/backend/src/domain/invitation/invitation.entity.ts
+++ b/FDP/backend/src/domain/invitation/invitation.entity.ts
@@ -14,8 +14,8 @@ export class Invitation {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  @Column({ type: 'varchar' })
-  inviteLink!: string;
+  @Column({ type: 'varchar', unique: true })
+  inviteCode!: string;
 
   @Column({ type: 'timestamp' })
   expiration!: Date;
@@ -25,6 +25,9 @@ export class Invitation {
     nullable: true,
   })
   group!: Group;
+
+  @Column({ type: 'boolean', default: true })
+  isActive!: boolean;
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt!: Date;

--- a/FDP/backend/src/domain/invitation/invitation.module.ts
+++ b/FDP/backend/src/domain/invitation/invitation.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { InvitationService } from './invitation.service';
+import { Invitation } from './invitation.entity';
+import { Group } from '../group/group.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Invitation, Group])],
+  providers: [InvitationService],
+  exports: [InvitationService],
+})
+export class InvitationModule {}

--- a/FDP/backend/src/domain/invitation/invitation.service.ts
+++ b/FDP/backend/src/domain/invitation/invitation.service.ts
@@ -79,8 +79,7 @@ export class InvitationService {
     });
 
     if (invitation) {
-      invitation.deletedAt = new Date();
-      await this.invitationRepository.save(invitation);
+      await this.invitationRepository.softDelete({ id: invitation.id });
     }
   }
 

--- a/FDP/backend/src/domain/invitation/invitation.service.ts
+++ b/FDP/backend/src/domain/invitation/invitation.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan, IsNull } from 'typeorm';
+import { Invitation } from './invitation.entity';
+import { Group } from '../group/group.entity';
+
+@Injectable()
+export class InvitationService {
+  private static readonly INVITE_CHARACTERS =
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  private static readonly CODE_LENGTH = 8;
+
+  constructor(
+    @InjectRepository(Invitation)
+    private invitationRepository: Repository<Invitation>,
+    @InjectRepository(Group)
+    private groupRepository: Repository<Group>
+  ) {}
+
+  async generateInviteLink(groupId: string, userId: string) {
+    const group = await this.groupRepository.findOne({
+      where: { id: groupId, deletedAt: IsNull() },
+    });
+    if (!group) {
+      throw new BadRequestException('존재하지 않는 그룹입니다.');
+    }
+
+    const inviteCode = await this.generateUniqueCode();
+    const invitation = this.invitationRepository.create({
+      inviteCode,
+      group: { id: groupId },
+      createdById: userId,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24시간 유효
+    });
+
+    return await this.invitationRepository.save(invitation);
+  }
+
+  async validateInvitation(inviteCode: string) {
+    const invitation = await this.invitationRepository.findOne({
+      where: {
+        inviteCode,
+        deletedAt: IsNull(),
+        expiresAt: MoreThan(new Date()),
+      },
+      relations: ['group'],
+    });
+
+    if (!invitation || invitation.group.deletedAt) {
+      throw new BadRequestException('유효하지 않은 초대 링크입니다.');
+    }
+
+    return invitation;
+  }
+
+  async getInvitationInfo(inviteCode: string) {
+    const invitation = await this.validateInvitation(inviteCode);
+    return {
+      groupId: invitation.group.id,
+      groupName: invitation.group.name,
+      expiresAt: invitation.expiresAt,
+    };
+  }
+
+  async deactivateInvitation(inviteCode: string) {
+    const invitation = await this.invitationRepository.findOne({
+      where: { inviteCode, deletedAt: IsNull() },
+    });
+
+    if (invitation) {
+      invitation.isActive = false;
+      await this.invitationRepository.save(invitation);
+    }
+  }
+
+  async deleteInvitation(inviteCode: string) {
+    const invitation = await this.invitationRepository.findOne({
+      where: { inviteCode, deletedAt: IsNull() },
+    });
+
+    if (invitation) {
+      invitation.deletedAt = new Date();
+      await this.invitationRepository.save(invitation);
+    }
+  }
+
+  private async generateUniqueCode(): Promise<string> {
+    let isUnique = false;
+    let inviteCode = '';
+
+    while (!isUnique) {
+      inviteCode = Array.from(
+        { length: InvitationService.CODE_LENGTH },
+        () =>
+          InvitationService.INVITE_CHARACTERS[
+            Math.floor(
+              Math.random() * InvitationService.INVITE_CHARACTERS.length
+            )
+          ]
+      ).join('');
+
+      const existingInvitation = await this.invitationRepository.findOne({
+        where: { inviteCode, deletedAt: IsNull() },
+      });
+
+      isUnique = !existingInvitation;
+    }
+
+    return inviteCode;
+  }
+}

--- a/FDP/backend/test/invitation/invitation.service.spec.ts
+++ b/FDP/backend/test/invitation/invitation.service.spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { InvitationService } from '../../src/domain/invitation/invitation.service';
+import { Invitation } from '../../src/domain/invitation/invitation.entity';
+import { Group } from '../../src/domain/group/group.entity';
+import { BadRequestException } from '@nestjs/common';
+import { IsNull } from 'typeorm';
+
+describe('InvitationService', () => {
+  let invitationService: InvitationService;
+
+  const mockGroupId = '123e4567-e89b-12d3-a456-426614174000';
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174001';
+
+  const mockInvitationRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    softDelete: jest.fn(),
+  };
+
+  const mockGroupRepository = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvitationService,
+        {
+          provide: getRepositoryToken(Invitation),
+          useValue: mockInvitationRepository,
+        },
+        {
+          provide: getRepositoryToken(Group),
+          useValue: mockGroupRepository,
+        },
+      ],
+    }).compile();
+
+    invitationService = module.get<InvitationService>(InvitationService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateInviteLink', () => {
+    it('should generate invite link successfully', async () => {
+      mockGroupRepository.findOne.mockResolvedValue({
+        id: mockGroupId,
+        name: 'Test Group',
+        deletedAt: null,
+      });
+      mockInvitationRepository.create.mockReturnValue({
+        inviteCode: 'testCode',
+        group: { id: mockGroupId },
+      });
+      mockInvitationRepository.save.mockResolvedValue({
+        inviteCode: 'testCode',
+        group: { id: mockGroupId },
+      });
+
+      const result = await invitationService.generateInviteLink(
+        mockGroupId,
+        mockUserId
+      );
+      expect(result).toBeDefined();
+    });
+
+    it('should throw BadRequestException if group does not exist', async () => {
+      mockGroupRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        invitationService.generateInviteLink(mockGroupId, mockUserId)
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('validateInvitation', () => {
+    const mockInvitation = {
+      inviteCode: 'testCode',
+      group: { id: mockGroupId, name: 'Test Group' },
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    };
+
+    it('should validate invitation successfully', async () => {
+      mockInvitationRepository.findOne.mockResolvedValue(mockInvitation);
+
+      const result = await invitationService.validateInvitation('testCode');
+
+      expect(result).toEqual(mockInvitation);
+      expect(mockInvitationRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          inviteCode: 'testCode',
+          deletedAt: IsNull(),
+          expiresAt: expect.any(Object),
+        },
+        relations: ['group'],
+      });
+    });
+
+    it('should throw BadRequestException for invalid invite code', async () => {
+      mockInvitationRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        invitationService.validateInvitation('invalidCode')
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getInvitationInfo', () => {
+    const mockInvitation = {
+      group: { id: 'group-id', name: 'Test Group' },
+      expiresAt: new Date(),
+    };
+
+    it('should return invitation info', async () => {
+      jest
+        .spyOn(invitationService, 'validateInvitation')
+        .mockResolvedValue(mockInvitation as any);
+
+      const result = await invitationService.getInvitationInfo('testCode');
+
+      expect(result).toEqual({
+        groupId: mockInvitation.group.id,
+        groupName: mockInvitation.group.name,
+        expiresAt: mockInvitation.expiresAt,
+      });
+    });
+  });
+
+  describe('deactivateInvitation', () => {
+    it('should deactivate invitation', async () => {
+      const mockInvitation = { inviteCode: 'testCode', isActive: true };
+      mockInvitationRepository.findOne.mockResolvedValue(mockInvitation);
+
+      await invitationService.deactivateInvitation('testCode');
+
+      expect(mockInvitationRepository.save).toHaveBeenCalledWith({
+        ...mockInvitation,
+        isActive: false,
+      });
+    });
+
+    it('should do nothing if invitation not found', async () => {
+      mockInvitationRepository.findOne.mockResolvedValue(null);
+
+      await invitationService.deactivateInvitation('testCode');
+
+      expect(mockInvitationRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteInvitation', () => {
+    it('should soft delete invitation', async () => {
+      const mockInvitation = { id: 'invitation-id', inviteCode: 'testCode' };
+      mockInvitationRepository.findOne.mockResolvedValue(mockInvitation);
+
+      await invitationService.deleteInvitation('testCode');
+
+      expect(mockInvitationRepository.softDelete).toHaveBeenCalledWith({
+        id: mockInvitation.id,
+      });
+    });
+
+    it('should do nothing if invitation not found', async () => {
+      mockInvitationRepository.findOne.mockResolvedValue(null);
+
+      await invitationService.deleteInvitation('testCode');
+
+      expect(mockInvitationRepository.softDelete).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# 초대 도메인 구현

## 작업 내용

### 초대 모듈 구현
- InvitationModule 도입으로 초대 관련 기능 캡슐화
- Entity, Service 구현
  - 초대 상태 관리 (활성/비활성)
  - Soft Delete 지원

### 테스트 구현
- Service 단위 테스트 구현
  - 초대 코드 생성 및 검증
  - 초대 상태 관리 테스트
  - 만료 처리 테스트

### 의존성 설정
- TypeORM 엔티티 관계 설정
  - Group과 ManyToOne 관계 설정
  - Soft Delete 컬럼 추가

## 향후 계획
1. 회원 시스템 완성 후
   - 초대 컨트롤러 구현
   - JWT 인증 연동
   - 권한 체크 추가

2. 그룹 시스템 완성 후
   - 그룹 멤버십 연동
   - 게스트 권한 처리
   - 초대 프로세스 완성

## 테스트 결과
[x] 초대 코드 생성 테스트 통과
[x] 초대 검증 테스트 통과
[x] 초대 정보 조회 테스트 통과
